### PR TITLE
Remove outdated IE notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,6 @@
         <script src="static/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js"></script>
     </head>
     <body>
-        <!--[if lt IE 7]>
-            <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a> to improve your experience.</p>
-        <![endif]-->
 
         <div class="container">
           <header>


### PR DESCRIPTION
## Summary
- delete the old `lt IE 7` message from `index.html`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6856e522f38883208f0bffe7ccfdda93